### PR TITLE
Use GET module to see if module exists instead of list with query

### DIFF
--- a/__tests__/publish.test.ts
+++ b/__tests__/publish.test.ts
@@ -45,7 +45,7 @@ test('Should publish the passed repository', async () => {
   }
 
   nock(`https://fake.terraform.io`)
-    .get(`/api/v2/organizations/org/oauth-clients`)
+    .get('/api/v2/organizations/org/oauth-clients')
     .reply(200, {
       data: [
         {
@@ -56,13 +56,11 @@ test('Should publish the passed repository', async () => {
         }
       ]
     })
-    .get(`/api/v2/oauth-clients/123/oauth-tokens`)
+    .get('/api/v2/oauth-clients/123/oauth-tokens')
     .reply(200, {data: [{id: '456'}]})
-    .get(
-      `/api/v2/organizations/org/registry-modules?filter=identifier%3Dorg%2Fterraform-unit-test`
-    )
-    .reply(200, {data: []})
-    .post(`/api/v2/organizations/org/registry-modules/vcs`)
+    .get('/api/v2/organizations/org/registry-modules/private/org/test/unit')
+    .reply(404, {response: {status: 404}})
+    .post('/api/v2/organizations/org/registry-modules/vcs')
     .reply(200, {
       data: {
         id: 'mod-123',
@@ -158,24 +156,20 @@ test('Should return the published repo if it has already been published', async 
         }
       ]
     })
-    .get(
-      `/api/v2/organizations/org/registry-modules?filter=identifier%3Dorg%2Fterraform-unit-test`
-    )
+    .get('/api/v2/organizations/org/registry-modules/private/org/test/unit')
     .reply(200, {
-      data: [
-        {
-          id: 'mod-123',
-          attributes: {
-            name: 'test',
-            namespace: 'org',
-            provider: 'terraform',
-            'vcs-repo': {
-              identifier: 'org/terraform-unit-test',
-              'display-identifier': 'org/terraform-unit-test'
-            }
+      data: {
+        id: 'mod-123',
+        attributes: {
+          name: 'test',
+          namespace: 'org',
+          provider: 'terraform',
+          'vcs-repo': {
+            identifier: 'org/terraform-unit-test',
+            'display-identifier': 'org/terraform-unit-test'
           }
         }
-      ]
+      }
     })
 
   await expect(
@@ -205,10 +199,8 @@ test('Should use the VCS token ID directly if passed', async () => {
   }
 
   nock(`https://fake.terraform.io`)
-    .get(
-      `/api/v2/organizations/org/registry-modules?filter=identifier%3Dorg%2Fterraform-unit-test`
-    )
-    .reply(200, {data: []})
+    .get('/api/v2/organizations/org/registry-modules/private/org/test/unit')
+    .reply(404, {response: {status: 404}})
     .post(`/api/v2/organizations/org/registry-modules/vcs`)
     .reply(200, {
       data: {

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -89,7 +89,7 @@ export async function publish(
   const tokenID =
     vcsTokenID || (await lookupVCSTokenID(tf, organization, vcsName!))
 
-  let rawModule: ModuleResponseData | null = null
+  let mod: ModuleResponseData | null = null
 
   const [, repoName] = repo.split('/')
   const [, provider, ...nameParts] = repoName.split('-')
@@ -101,16 +101,16 @@ export async function publish(
       method: 'get'
     })
 
-    rawModule = published.data.data as ModuleResponseData
+    mod = published.data.data as ModuleResponseData
   } catch (err) {
     if (err.response.status !== 404) {
       throw err
     }
   }
 
-  if (!rawModule) {
+  if (!mod) {
     try {
-      rawModule = (
+      mod = (
         await tf({
           url: `/organizations/${organization}/registry-modules/vcs`,
           method: 'post',
@@ -130,7 +130,7 @@ export async function publish(
       ).data.data as ModuleResponseData
 
       core.info(
-        `Module "${rawModule.attributes.name}" from repository "${repo}" was published.`
+        `Module "${mod.attributes.name}" from repository "${repo}" was published.`
       )
     } catch (err) {
       core.error(JSON.stringify(err.response.data))
@@ -138,11 +138,11 @@ export async function publish(
     }
   } else {
     core.info(
-      `No action. Module "${rawModule.attributes.name}" from repository "${repo}" was already published.`
+      `No action. Module "${mod.attributes.name}" from repository "${repo}" was already published.`
     )
   }
 
-  const module = newModuleFromResponse(rawModule)
+  const module = newModuleFromResponse(mod)
 
   const {origin} = new URL(tf.defaults.baseURL as string)
   module.link = `${origin}/app/${organization}/registry/modules/private/${module.namespace}/${module.name}/${module.provider}`

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -89,15 +89,24 @@ export async function publish(
   const tokenID =
     vcsTokenID || (await lookupVCSTokenID(tf, organization, vcsName!))
 
-  const published = await tf({
-    url: `/organizations/${organization}/registry-modules`,
-    method: 'get',
-    params: {
-      filter: `identifier=${repo}`
-    }
-  })
+  let rawModule: ModuleResponseData | null = null
 
-  let rawModule: ModuleResponseData = published.data.data[0]
+  const [, repoName] = repo.split('/')
+  const [, provider, ...nameParts] = repoName.split('-')
+  const name = nameParts.join('-')
+
+  try {
+    const published = await tf({
+      url: `/organizations/${organization}/registry-modules/private/${organization}/${name}/${provider}`,
+      method: 'get'
+    })
+
+    rawModule = published.data.data as ModuleResponseData
+  } catch (err) {
+    if (err.response.status !== 404) {
+      throw err
+    }
+  }
 
   if (!rawModule) {
     try {
@@ -112,7 +121,7 @@ export async function publish(
                 vcs_repo: {
                   identifier: repo,
                   'oauth-token-id': tokenID,
-                  display_identifier: displayIdentifier,
+                  display_identifier: displayIdentifier
                 }
               }
             }
@@ -120,13 +129,17 @@ export async function publish(
         })
       ).data.data as ModuleResponseData
 
-      core.info(`Module "${rawModule.attributes.name}" from repository "${repo}" was published.`)
+      core.info(
+        `Module "${rawModule.attributes.name}" from repository "${repo}" was published.`
+      )
     } catch (err) {
       core.error(JSON.stringify(err.response.data))
       throw err
     }
   } else {
-    core.info(`No action. Module "${rawModule.attributes.name}" from repository "${repo}" was already published.`)
+    core.info(
+      `No action. Module "${rawModule.attributes.name}" from repository "${repo}" was already published.`
+    )
   }
 
   const module = newModuleFromResponse(rawModule)
@@ -135,6 +148,6 @@ export async function publish(
   module.link = `${origin}/app/${organization}/registry/modules/private/${module.namespace}/${module.name}/${module.provider}`
 
   core.info(module.link)
-  
+
   return module
 }


### PR DESCRIPTION
I had missed that there was a simple GET endpoint for returning a module. Hindsight, of course there is. 

Anyway, this will be a better approach for figuring out if a module exists already in the registry than using filters and query params, no pagination, no potential overlap with query filters, just a simple get.